### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a Model Context Protocol (MCP) server built with TypeScript. It provides a versatile tool to fetch and parse any standard RSS/Atom feed, and also includes special support for [RSSHub](https://docs.rsshub.app/) feeds. With this server, language models or other MCP clients can easily retrieve structured content from various web sources.
 
+<a href="https://glama.ai/mcp/servers/@veithly/rss-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@veithly/rss-mcp/badge" alt="RSS Server MCP server" />
+</a>
+
 The server comes with a built-in list of public RSSHub instances and supports a polling mechanism to automatically select an available instance, significantly improving the success rate and stability of data retrieval.
 
 ## ✨ Features


### PR DESCRIPTION
This PR adds a badge for the [RSS MCP Server](https://glama.ai/mcp/servers/@veithly/rss-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@veithly/rss-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@veithly/rss-mcp/badge" alt="RSS Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.