### PR TITLE
Convert to Vercel-deployable HTTP MCP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Optional: Set your priority RSSHub instance
+# This instance will be tried first before falling back to public instances
+PRIORITY_RSSHUB_INSTANCE=https://your-rsshub-instance.com

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@
 
 # Build output
 /dist
+/.next
+/out
+
+# Next.js
+next-env.d.ts
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -2,111 +2,137 @@
 
 [![NPM Version](https://img.shields.io/npm/v/rss-mcp.svg)](https://www.npmjs.com/package/rss-mcp)
 
-This is a Model Context Protocol (MCP) server built with TypeScript. It provides a versatile tool to fetch and parse any standard RSS/Atom feed, and also includes special support for [RSSHub](https://docs.rsshub.app/) feeds. With this server, language models or other MCP clients can easily retrieve structured content from various web sources.
+A Model Context Protocol (MCP) server for fetching and parsing RSS/Atom feeds with RSSHub support. This server can be deployed to Vercel as a remote MCP server or run locally via stdio.
 
-The server comes with a built-in list of public RSSHub instances and supports a polling mechanism to automatically select an available instance, significantly improving the success rate and stability of data retrieval.
-
-## ✨ Features
+## Features
 
 - **Universal Feed Parsing**: Fetch and parse any standard RSS/Atom feed from a given URL.
-- **Enhanced RSSHub Support**: Provides a tool named `get_feed` to fetch any RSSHub-supported feed via MCP, with multi-instance support.
+- **Enhanced RSSHub Support**: Fetch any RSSHub-supported feed via MCP, with multi-instance support.
 - **Customizable Item Count**: Specify the number of feed items to retrieve, with support for fetching all items.
 - **Multi-instance Support**: Includes a list of public RSSHub instances and automatically polls to find an available service.
 - **Smart URL Parsing**: Supports standard RSSHub URLs and a simplified `rsshub://` protocol format.
-- **Priority Instance Configuration**: Allows setting a preferred RSSHub instance via the `PRIORITY_RSSHUB_INSTANCE` environment variable.
-- **Robust Error Handling**: If a request to one instance fails, it automatically tries the next one until it succeeds or all instances have failed.
+- **Priority Instance Configuration**: Set a preferred RSSHub instance via the `PRIORITY_RSSHUB_INSTANCE` environment variable.
+- **Robust Error Handling**: If a request to one instance fails, it automatically tries the next one until it succeeds.
 - **Content Cleaning**: Uses Cheerio to clean the feed content and extract plain text descriptions.
-- **Standardized Output**: Converts the fetched RSS feed into a structured JSON format.
+- **Vercel Deployment**: Deploy as a remote MCP server accessible via HTTPS.
 
-## 📦 Installation
+## Deployment Options
 
-First, clone the project repository, then install the required dependencies.
+### Option 1: Deploy to Vercel (Recommended)
+
+Deploy your own RSS MCP server to Vercel with one click:
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/zacfire/rss-mcp)
+
+Or deploy manually:
 
 ```bash
-git clone https://github.com/veithly/rss-mcp.git
+# Clone the repository
+git clone https://github.com/zacfire/rss-mcp.git
+cd rss-mcp
+
+# Install dependencies
+npm install
+
+# Deploy to Vercel
+npx vercel
+
+# Or deploy to production
+npx vercel --prod
+```
+
+After deployment, you'll get an HTTPS URL like: `https://your-rss-mcp.vercel.app`
+
+#### Environment Variables (Optional)
+
+In your Vercel project settings, you can set:
+
+- `PRIORITY_RSSHUB_INSTANCE`: Your preferred RSSHub instance URL (e.g., `https://my-rsshub.example.com`)
+
+### Option 2: Run Locally via stdio
+
+For local development or traditional MCP usage:
+
+```bash
+# Clone and install
+git clone https://github.com/zacfire/rss-mcp.git
 cd rss-mcp
 npm install
+
+# Build for stdio mode
+npm run build:stdio
+
+# Run the server
+npm run start:stdio
 ```
 
-## 🚀 Usage
-
-### 1. Build the Project
-
-Before running, you need to compile the TypeScript code into JavaScript:
+### Option 3: Use via npx
 
 ```bash
-npm run build
+npx rss-mcp
 ```
 
-### 2. Run the Server
+## MCP Client Configuration
 
-After a successful build, start the MCP server:
+### For Cursor (Remote Server)
 
-```bash
-npm start
-```
+Add to your Cursor settings (`~/.cursor/mcp.json`):
 
-The server will then communicate with the parent process (e.g., Cursor) via Stdio.
-
-### 3. Configure a Priority Instance (Optional)
-
-You can create a `.env` file to specify a priority RSSHub instance. This is very useful for users who have a private, stable instance.
-
-Create a `.env` file in the project root directory and add the following content:
-
-```env
-PRIORITY_RSSHUB_INSTANCE=https://my-rsshub.example.com
-```
-
-The server will automatically load this configuration on startup and place it at the top of the polling list.
-
-## 🔧 MCP Server Configuration
-
-To use this server with an MCP client like Cursor, you need to add it to your configuration file.
-
-### Method 1: Using `npx` (Recommended)
-
-This package is published on npm, so you can use `npx` to run the server without a local installation. This is the easiest method.
-
-1.  **Direct Invocation**:
-    You can run the server directly from your terminal using `npx`:
-
-    ```bash
-    npx rss-mcp
-    ```
-
-2.  **MCP Client Configuration**:
-    To integrate with an MCP client like Cursor, add the following to your configuration file (e.g., `~/.cursor/mcp_settings.json`):
-
-    ```json
-    {
-      "name": "rss",
-      "command": ["npx", "rss-mcp"],
-      "type": "stdio"
+```json
+{
+  "mcpServers": {
+    "rss": {
+      "url": "https://your-rss-mcp.vercel.app/api"
     }
-    ```
+  }
+}
+```
 
-### Method 2: Local Installation
+### For Claude Desktop (Remote Server)
 
-If you have cloned the repository locally, you can run it directly with `node`.
+Claude Desktop requires `mcp-remote` to connect to remote servers. Add to your Claude Desktop config:
 
-1.  **Clone and build the project** as described in the "Installation" and "Usage" sections.
-2.  **Locate your MCP configuration file.**
-3.  Add the following server entry, making sure to use the **absolute path** to the compiled `index.js` file:
-
-    ```json
-    {
-      "name": "rss",
-      "command": ["node", "/path/to/your/rss-mcp/dist/index.js"],
-      "type": "stdio"
+```json
+{
+  "mcpServers": {
+    "rss": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://your-rss-mcp.vercel.app/api"
+      ]
     }
-    ```
+  }
+}
+```
 
-    **Important:** Replace `/path/to/your/rss-mcp/dist/index.js` with the correct absolute path on your system.
+### For Local stdio Mode
 
-After adding the configuration, **restart your MCP client** (e.g., Cursor) for the changes to take effect. The `rss` server will then be available, and you can call the `get_feed` tool.
+```json
+{
+  "mcpServers": {
+    "rss": {
+      "command": "npx",
+      "args": ["rss-mcp"]
+    }
+  }
+}
+```
 
-## 🛠️ Tool Definition
+Or with a local installation:
+
+```json
+{
+  "mcpServers": {
+    "rss": {
+      "command": "node",
+      "args": ["/path/to/your/rss-mcp/dist/index.js"]
+    }
+  }
+}
+```
+
+## Tool Definition
 
 ### `get_feed`
 
@@ -114,16 +140,17 @@ Fetches and parses an RSS feed from a given URL. It supports both standard RSS/A
 
 #### Input Parameters
 
-- `url` (string, required): The URL of the RSS feed to fetch. Two formats are supported:
-    1.  **Standard URL**: `https://rsshub.app/bilibili/user/dynamic/208259`
-    2.  **`rsshub://` protocol**: `rsshub://bilibili/user/dynamic/208259` (the server will automatically match an available instance)
+- `url` (string, required): The URL of the RSS feed to fetch. Supported formats:
+    1. **Standard URL**: `https://rsshub.app/bilibili/user/dynamic/208259`
+    2. **`rsshub://` protocol**: `rsshub://bilibili/user/dynamic/208259`
+    3. **Short path**: `bilibili/user/dynamic/208259` (automatically converted to rsshub://)
 - `count` (number, optional): The number of RSS feed items to retrieve.
     - **Default**: `1`
     - **Retrieve all**: `0`
 
 #### Output
 
-Returns a JSON string containing the feed information, with the following structure:
+Returns a JSON string containing the feed information:
 
 ```json
 {
@@ -144,15 +171,55 @@ Returns a JSON string containing the feed information, with the following struct
 }
 ```
 
-## 📜 Main Dependencies
+## Local Development
 
-- [@modelcontextprotocol/sdk](https://www.npmjs.com/package/@modelcontextprotocol/sdk): For building the MCP server.
-- [axios](https://www.npmjs.com/package/axios): For making HTTP requests.
-- [rss-parser](https://www.npmjs.com/package/rss-parser): For parsing RSS/Atom feeds.
-- [cheerio](https://www.npmjs.com/package/cheerio): For parsing and manipulating HTML content.
-- [date-fns-tz](https://www.npmjs.com/package/date-fns-tz): For handling time-zone-related date formatting.
-- [dotenv](https://www.npmjs.com/package/dotenv): For loading environment variables from a `.env` file.
+```bash
+# Install dependencies
+npm install
 
-## 📄 License
+# Run development server
+npm run dev
+
+# The server will be available at http://localhost:3000
+# MCP endpoint: http://localhost:3000/api
+```
+
+## Project Structure
+
+```
+rss-mcp/
+├── app/
+│   ├── api/
+│   │   └── [transport]/
+│   │       └── route.ts        # MCP handler for Vercel
+│   ├── layout.tsx              # Root layout
+│   └── page.tsx                # Homepage with API documentation
+├── src/
+│   ├── lib/
+│   │   ├── feed-parser.ts      # Core RSS parsing logic
+│   │   ├── rsshub-instances.ts # RSSHub instance management
+│   │   ├── types.ts            # TypeScript types
+│   │   └── index.ts            # Module exports
+│   └── index.ts                # stdio server entry point
+├── .env.example
+├── next.config.js
+├── vercel.json
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+## Main Dependencies
+
+- [mcp-handler](https://www.npmjs.com/package/mcp-handler): Vercel adapter for MCP servers
+- [@modelcontextprotocol/sdk](https://www.npmjs.com/package/@modelcontextprotocol/sdk): MCP SDK
+- [next](https://www.npmjs.com/package/next): React framework for production
+- [axios](https://www.npmjs.com/package/axios): HTTP client
+- [rss-parser](https://www.npmjs.com/package/rss-parser): RSS/Atom feed parser
+- [cheerio](https://www.npmjs.com/package/cheerio): HTML parser for content cleaning
+- [date-fns-tz](https://www.npmjs.com/package/date-fns-tz): Timezone-aware date formatting
+- [zod](https://www.npmjs.com/package/zod): Schema validation
+
+## License
 
 This project is licensed under the Apache-2.0 License.

--- a/README.md
+++ b/README.md
@@ -20,34 +20,68 @@ A Model Context Protocol (MCP) server for fetching and parsing RSS/Atom feeds wi
 
 ### Option 1: Deploy to Vercel (Recommended)
 
-Deploy your own RSS MCP server to Vercel with one click:
+#### Method A: One-Click Deploy
+
+Deploy with a single click using Vercel's deployment button:
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/zacfire/rss-mcp)
 
-Or deploy manually:
+#### Method B: Deploy via Vercel Dashboard
+
+1. Visit [Vercel Dashboard](https://vercel.com/new)
+2. Click "Import Project"
+3. Connect your GitHub account and select the `zacfire/rss-mcp` repository
+4. Select the branch you want to deploy (e.g., `main` or your feature branch)
+5. Vercel will auto-detect Next.js settings
+6. Click "Deploy"
+7. Wait for deployment to complete (usually 1-2 minutes)
+
+After deployment, you'll get:
+- **Production URL**: `https://your-project-name.vercel.app`
+- **MCP Endpoint**: `https://your-project-name.vercel.app/api`
+
+**Benefits of Dashboard Deployment:**
+- Auto-deploys on every push to the connected branch
+- Preview deployments for pull requests
+- Easy environment variable management
+- Deployment history and rollback support
+
+#### Method C: Deploy via CLI
+
+For manual deployment from your local machine:
 
 ```bash
-# Clone the repository
+# 1. Clone the repository (if not already cloned)
 git clone https://github.com/zacfire/rss-mcp.git
 cd rss-mcp
 
-# Install dependencies
-npm install
+# 2. Install Vercel CLI globally (first time only)
+npm install -g vercel
 
-# Deploy to Vercel
-npx vercel
+# 3. Login to Vercel
+vercel login
 
-# Or deploy to production
-npx vercel --prod
+# 4. Deploy to preview environment
+vercel
+
+# 5. Deploy to production
+vercel --prod
 ```
 
-After deployment, you'll get an HTTPS URL like: `https://your-rss-mcp.vercel.app`
+#### Setting Environment Variables
 
-#### Environment Variables (Optional)
+In your Vercel project settings, you can optionally set:
 
-In your Vercel project settings, you can set:
+- **`PRIORITY_RSSHUB_INSTANCE`**: Your preferred RSSHub instance URL
+  - Example: `https://my-rsshub.example.com`
+  - This instance will be tried first before falling back to public instances
 
-- `PRIORITY_RSSHUB_INSTANCE`: Your preferred RSSHub instance URL (e.g., `https://my-rsshub.example.com`)
+**How to set environment variables:**
+1. Go to your project in Vercel Dashboard
+2. Navigate to Settings → Environment Variables
+3. Add `PRIORITY_RSSHUB_INSTANCE` with your value
+4. Select environment (Production, Preview, Development)
+5. Click "Save" - this will trigger a new deployment
 
 ### Option 2: Run Locally via stdio
 
@@ -219,6 +253,87 @@ rss-mcp/
 - [cheerio](https://www.npmjs.com/package/cheerio): HTML parser for content cleaning
 - [date-fns-tz](https://www.npmjs.com/package/date-fns-tz): Timezone-aware date formatting
 - [zod](https://www.npmjs.com/package/zod): Schema validation
+
+## Verifying Your Deployment
+
+After deploying to Vercel, verify that everything works:
+
+### 1. Check the Homepage
+
+Visit your deployment URL (e.g., `https://your-project-name.vercel.app`)
+
+You should see:
+- Server name and description
+- MCP endpoint URL
+- Available tools documentation
+- Client configuration examples
+
+### 2. Test the MCP Endpoint
+
+The MCP endpoint is available at: `https://your-project-name.vercel.app/api`
+
+You can test it by:
+1. Adding it to your MCP client configuration (Cursor or Claude Desktop)
+2. Trying the `get_feed` tool with a test URL
+
+### 3. Example Test
+
+In Cursor or Claude Desktop, try:
+```
+Use the rss tool to get the feed from: rsshub://github/issue/anthropics/anthropic-sdk-typescript
+```
+
+## Troubleshooting
+
+### Vercel Deployment Issues
+
+**Error: "No Output Directory named 'public' found"**
+- Solution: The `public` directory should be auto-created. If missing, run:
+  ```bash
+  mkdir public
+  git add public
+  git commit -m "Add public directory"
+  git push
+  ```
+
+**Error: "Build failed" or TypeScript errors**
+- Check the build logs in Vercel Dashboard
+- Ensure all dependencies are installed: `npm install`
+- Test locally first: `npm run build`
+
+**Error: "Function timeout"**
+- Some RSS feeds may take longer to fetch
+- The `vercel.json` already sets `maxDuration: 60` seconds
+- For Vercel Pro accounts, you can increase this limit
+
+### MCP Connection Issues
+
+**Client can't connect to the server**
+- Verify the URL is correct: `https://your-project-name.vercel.app/api`
+- Check that the deployment is live (visit the URL in browser)
+- For Claude Desktop, ensure `mcp-remote` is installed: `npx mcp-remote --version`
+
+**Tool returns errors**
+- Check Vercel function logs in Dashboard → Deployments → [Latest] → Functions
+- Verify the RSS/RSSHub URL is accessible
+- Try a different RSSHub instance by setting `PRIORITY_RSSHUB_INSTANCE`
+
+### Local Development Issues
+
+**Port 3000 already in use**
+- Change the port: `PORT=3001 npm run dev`
+- Or kill the process using port 3000
+
+**TypeScript errors during development**
+- Run `npm install` to ensure all type definitions are installed
+- Check that `tsconfig.json` is properly configured
+
+## Performance Notes
+
+- **Cold Starts**: First request after inactivity may take 2-3 seconds (Vercel serverless warm-up)
+- **Timeout**: RSS fetching has a 15-second timeout per instance, 60-second function limit
+- **RSSHub Fallback**: If one instance fails, it automatically tries the next one
+- **Caching**: Consider implementing caching for frequently accessed feeds
 
 ## License
 

--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -1,0 +1,45 @@
+import { createMcpHandler } from 'mcp-handler';
+import { z } from 'zod';
+import { getFeed } from '../../../src/lib';
+
+const handler = createMcpHandler(
+  (server) => {
+    server.tool(
+      'get_feed',
+      'Get RSS feed from any URL, including RSSHub feeds.',
+      {
+        url: z.string().describe("URL of the RSS feed. For RSSHub, you can use 'rsshub://' protocol (e.g., 'rsshub://bilibili/user/dynamic/208259')."),
+        count: z.number().optional().describe("Number of RSS feed items to retrieve. Defaults to 1. Set to 0 to retrieve all items.")
+      },
+      async ({ url, count }) => {
+        try {
+          console.log(`Tool called with URL: ${url} and count: ${count}`);
+          const feedResult = await getFeed({ url, count });
+          console.log(`Tool completed successfully for URL: ${url}`);
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(feedResult, null, 2) }]
+          };
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+          console.error(`Tool error for URL ${url}: ${errorMessage}`);
+          return {
+            content: [{ type: 'text' as const, text: `Error fetching RSS feed: ${errorMessage}` }],
+            isError: true
+          };
+        }
+      }
+    );
+  },
+  {
+    capabilities: {
+      tools: {}
+    }
+  },
+  {
+    basePath: '/api',
+    verboseLogs: true,
+    maxDuration: 60
+  }
+);
+
+export { handler as GET, handler as POST, handler as DELETE };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'RSS MCP Server',
+  description: 'A Model Context Protocol server for fetching and parsing RSS/Atom feeds with RSSHub support',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body style={{
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+        margin: 0,
+        padding: 0,
+        backgroundColor: '#f5f5f5'
+      }}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,146 @@
+export default function Home() {
+  return (
+    <main style={{
+      maxWidth: '800px',
+      margin: '0 auto',
+      padding: '40px 20px',
+      lineHeight: '1.6'
+    }}>
+      <h1 style={{ color: '#333', marginBottom: '20px' }}>RSS MCP Server</h1>
+
+      <p style={{ color: '#666', marginBottom: '30px' }}>
+        A Model Context Protocol (MCP) server for fetching and parsing RSS/Atom feeds with RSSHub support.
+      </p>
+
+      <section style={{
+        backgroundColor: '#fff',
+        padding: '20px',
+        borderRadius: '8px',
+        marginBottom: '20px',
+        boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+      }}>
+        <h2 style={{ color: '#333', marginTop: 0 }}>MCP Endpoint</h2>
+        <code style={{
+          display: 'block',
+          backgroundColor: '#f4f4f4',
+          padding: '15px',
+          borderRadius: '4px',
+          wordBreak: 'break-all'
+        }}>
+          {typeof window !== 'undefined' ? `${window.location.origin}/api` : '/api'}
+        </code>
+      </section>
+
+      <section style={{
+        backgroundColor: '#fff',
+        padding: '20px',
+        borderRadius: '8px',
+        marginBottom: '20px',
+        boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+      }}>
+        <h2 style={{ color: '#333', marginTop: 0 }}>Available Tool</h2>
+
+        <h3 style={{ color: '#555' }}>get_feed</h3>
+        <p style={{ color: '#666' }}>
+          Fetches and parses an RSS feed from a given URL. Supports both standard RSS/Atom feeds and RSSHub feeds.
+        </p>
+
+        <h4 style={{ color: '#555' }}>Parameters:</h4>
+        <ul style={{ color: '#666' }}>
+          <li>
+            <strong>url</strong> (string, required): The URL of the RSS feed. Supports:
+            <ul>
+              <li>Standard URLs: <code>https://rsshub.app/bilibili/user/dynamic/208259</code></li>
+              <li>rsshub:// protocol: <code>rsshub://bilibili/user/dynamic/208259</code></li>
+              <li>Short paths: <code>bilibili/user/dynamic/208259</code></li>
+            </ul>
+          </li>
+          <li>
+            <strong>count</strong> (number, optional): Number of items to retrieve. Default: 1, Set to 0 for all items.
+          </li>
+        </ul>
+      </section>
+
+      <section style={{
+        backgroundColor: '#fff',
+        padding: '20px',
+        borderRadius: '8px',
+        marginBottom: '20px',
+        boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+      }}>
+        <h2 style={{ color: '#333', marginTop: 0 }}>Client Configuration</h2>
+
+        <h3 style={{ color: '#555' }}>For Cursor</h3>
+        <pre style={{
+          backgroundColor: '#f4f4f4',
+          padding: '15px',
+          borderRadius: '4px',
+          overflow: 'auto'
+        }}>
+{`{
+  "mcpServers": {
+    "rss": {
+      "url": "${typeof window !== 'undefined' ? window.location.origin : 'https://your-rss-mcp.vercel.app'}/api"
+    }
+  }
+}`}
+        </pre>
+
+        <h3 style={{ color: '#555' }}>For Claude Desktop</h3>
+        <pre style={{
+          backgroundColor: '#f4f4f4',
+          padding: '15px',
+          borderRadius: '4px',
+          overflow: 'auto'
+        }}>
+{`{
+  "mcpServers": {
+    "rss": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "${typeof window !== 'undefined' ? window.location.origin : 'https://your-rss-mcp.vercel.app'}/api"
+      ]
+    }
+  }
+}`}
+        </pre>
+      </section>
+
+      <section style={{
+        backgroundColor: '#fff',
+        padding: '20px',
+        borderRadius: '8px',
+        boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+      }}>
+        <h2 style={{ color: '#333', marginTop: 0 }}>Features</h2>
+        <ul style={{ color: '#666' }}>
+          <li>Universal RSS/Atom feed parsing</li>
+          <li>RSSHub multi-instance support with automatic failover</li>
+          <li>Smart URL parsing (rsshub:// protocol)</li>
+          <li>Customizable item count</li>
+          <li>Content cleaning with plain text extraction</li>
+          <li>Priority instance configuration via environment variable</li>
+        </ul>
+      </section>
+
+      <footer style={{
+        marginTop: '40px',
+        textAlign: 'center',
+        color: '#999',
+        fontSize: '14px'
+      }}>
+        <p>
+          <a
+            href="https://github.com/zacfire/rss-mcp"
+            style={{ color: '#666', textDecoration: 'none' }}
+          >
+            GitHub Repository
+          </a>
+          {' | '}
+          <span>Apache-2.0 License</span>
+        </p>
+      </footer>
+    </main>
+  );
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,18 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // Enable experimental features if needed
+  experimental: {
+    // Server Actions are stable in Next.js 14+
+  },
+  // Ignore TypeScript errors during build (optional, remove in production)
+  typescript: {
+    // Set to true if you want to ignore TS errors during build
+    ignoreBuildErrors: false,
+  },
+  // Ignore ESLint errors during build (optional)
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+};
+
+export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rss-mcp",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rss-mcp",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.2",
@@ -15,13 +15,20 @@
         "date-fns": "^3.6.0",
         "date-fns-tz": "^3.1.3",
         "dotenv": "^16.4.5",
-        "rss-parser": "^3.13.0"
+        "mcp-handler": "^1.0.3",
+        "next": "^14.2.18",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "rss-parser": "^3.13.0",
+        "zod": "^3.24.0"
       },
       "bin": {
         "rss-mcp": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^20.14.9",
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
       }
@@ -50,9 +57,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -68,16 +75,18 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.13.2.tgz",
-      "integrity": "sha512-Vx7qOcmoKkR3qhaQ9qf3GxiVKCEu+zfJddHv6x3dY/9P6+uIwJnmuAur5aB+4FDXf41rRrDnOEGkviX5oYZ67w==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.22.0.tgz",
+      "integrity": "sha512-VUpl106XVTCpDmTBil2ehgJZjhyLY2QZikzF8NvTXtLRF1CvO5iEE2UNZdVIUer35vFOwMKYeUGbjJtvPWan3g==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.6",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "pkce-challenge": "^5.0.0",
@@ -87,12 +96,245 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.33.tgz",
+      "integrity": "sha512-CgVHNZ1fRIlxkLhIX22flAZI/HmpDaZ8vwyJ/B0SDPTBuLZ1PJ+DWMjCHhqnExfmSQzA/PbZi8OAc7PAq2w9IA==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -118,13 +360,41 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.2.tgz",
-      "integrity": "sha512-9pLGGwdzOUBDYi0GNjM97FIA+f92fqSke6joWeBjWXllfNxZBs7qeMF7tvtOIsbY45xkWkxrdwUfUf3MnQa9gA==",
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.27",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
+      "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/accepts": {
@@ -167,19 +437,36 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/arg": {
@@ -196,13 +483,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -231,6 +518,17 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -270,26 +568,58 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001756",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001756.tgz",
+      "integrity": "sha512-4HnCNKbMLkLdhJz3TToeVWHSnfJvPaq6vu/eRP0Ahub/07n484XHhBF5AJoSGHdVrS8tKFauUQz8Bp9P7LVx7A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/cheerio": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.0.tgz",
-      "integrity": "sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
       "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
-        "encoding-sniffer": "^0.2.0",
+        "encoding-sniffer": "^0.2.1",
         "htmlparser2": "^10.0.0",
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.10.0",
+        "undici": "^7.12.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
@@ -312,6 +642,21 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -324,16 +669,26 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=16"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -398,9 +753,9 @@
       }
     },
     "node_modules/css-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
@@ -414,9 +769,9 @@
       }
     },
     "node_modules/css-what": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
@@ -424,6 +779,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/date-fns": {
       "version": "3.6.0",
@@ -445,9 +807,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -545,9 +907,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -683,9 +1045,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
-      "integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -734,9 +1096,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -745,7 +1107,7 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -754,11 +1116,21 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "license": "MIT"
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/finalhandler": {
       "version": "2.1.0",
@@ -778,9 +1150,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -798,9 +1170,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -861,6 +1233,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -909,6 +1290,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
@@ -1044,11 +1431,29 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -1064,6 +1469,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-handler": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mcp-handler/-/mcp-handler-1.0.3.tgz",
+      "integrity": "sha512-AQ8I1a6wyfK0hIHeGqvjXqKHGvABDvw5dvwJvMjUiuKAUDgFsFtPExqThFOE/boOTbBKXn7fPSJ94soT0GjL+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^11.1.0",
+        "redis": "^4.6.0"
+      },
+      "bin": {
+        "create-mcp-route": "dist/cli/index.js",
+        "mcp-adapter": "dist/cli/index.js",
+        "mcp-handler": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.17.2",
+        "next": ">=13.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": false
+        },
+        "next": {
+          "optional": true
+        }
       }
     },
     "node_modules/media-typer": {
@@ -1114,6 +1547,24 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -1121,6 +1572,56 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.33.tgz",
+      "integrity": "sha512-GiKHLsD00t4ACm1p00VgrI0rUFAC9cRDGReKyERlM57aeEZkOQGcZTpIbsGn0b562FTPJWmYfKwplfO9EaT6ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.33",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
       }
     },
     "node_modules/nth-check": {
@@ -1245,13 +1746,20 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.0",
@@ -1260,6 +1768,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/proxy-addr": {
@@ -1280,15 +1816,6 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/qs": {
       "version": "6.14.0",
@@ -1315,18 +1842,85 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.7.0",
         "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/router": {
@@ -1364,26 +1958,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -1391,10 +1965,19 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "license": "ISC"
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
+      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/send": {
       "version": "1.2.0",
@@ -1532,6 +2115,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1539,6 +2131,37 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/toidentifier": {
@@ -1594,6 +2217,12 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1609,9 +2238,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1623,9 +2252,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.10.0.tgz",
-      "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -1645,15 +2274,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -1736,6 +2356,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -1747,21 +2373,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.63",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.63.tgz",
-      "integrity": "sha512-3ttCkqhtpncYXfP0f6dsyabbYV/nEUW+Xlu89jiXbTBifUfjaSqXOG6JnQPLtqt87n7KAmnMqcjay6c0Wq0Vbw==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
+      "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,19 +1,28 @@
 {
   "name": "rss-mcp",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
     "rss-mcp": "dist/index.js"
   },
   "scripts": {
-    "build": "tsc",
-    "start": "node dist/index.js"
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "build:stdio": "tsc",
+    "start:stdio": "node dist/index.js"
   },
-  "keywords": [],
+  "keywords": [
+    "mcp",
+    "rss",
+    "rsshub",
+    "model-context-protocol",
+    "vercel"
+  ],
   "author": "",
   "license": "Apache-2.0",
-  "description": "",
+  "description": "A Model Context Protocol server for fetching and parsing RSS/Atom feeds with RSSHub support",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.13.2",
     "axios": "^1.10.0",
@@ -21,10 +30,17 @@
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.1.3",
     "dotenv": "^16.4.5",
-    "rss-parser": "^3.13.0"
+    "mcp-handler": "^1.0.3",
+    "next": "^14.2.18",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "rss-parser": "^3.13.0",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.9",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   }

--- a/src/lib/feed-parser.ts
+++ b/src/lib/feed-parser.ts
@@ -1,0 +1,143 @@
+// Core RSS feed parsing logic
+
+import axios from 'axios';
+import Parser from 'rss-parser';
+import * as cheerio from 'cheerio';
+import { formatInTimeZone } from 'date-fns-tz';
+import { convertRsshubUrl } from './rsshub-instances';
+import { RssFeed, RssItem } from './types';
+
+export interface GetFeedParams {
+    url: string;
+    count?: number;
+}
+
+export async function getFeed(params: GetFeedParams): Promise<RssFeed> {
+    try {
+        let currentUrl = params.url;
+
+        if (typeof currentUrl !== 'string') {
+            throw new Error("URL must be a string.");
+        }
+
+        // Handle JSON string input
+        try {
+            const parsed = JSON.parse(currentUrl);
+            if (parsed && typeof parsed === 'object' && parsed.url) {
+                currentUrl = parsed.url;
+            }
+        } catch {
+            // Not a JSON string, use as is
+        }
+
+        if (!currentUrl.includes('://')) {
+            currentUrl = `rsshub://${currentUrl}`;
+        }
+
+        const urls = convertRsshubUrl(currentUrl);
+
+        const userAgents = [
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0"
+        ];
+
+        const headers = {
+            "User-Agent": userAgents[Math.floor(Math.random() * userAgents.length)],
+            "Accept": "application/rss+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+            "Accept-Encoding": "gzip, deflate, br"
+        };
+
+        let lastError: Error | null = null;
+
+        for (const u of urls) {
+            try {
+                console.log(`Attempting to fetch from ${u}...`);
+                const response = await axios.get(u, {
+                    headers,
+                    timeout: 15000, // Reduced timeout to fail faster
+                    maxRedirects: 3,
+                    validateStatus: (status) => status >= 200 && status < 300,
+                    responseType: 'text', // Ensure response is treated as text
+                });
+
+                if (!response.data) {
+                    throw new Error("Empty response data");
+                }
+
+                const parser = new Parser({
+                    timeout: 10000, // Parser timeout
+                    maxRedirects: 3,
+                });
+                const feed = await parser.parseString(response.data);
+
+                if (!feed || !feed.items) {
+                    throw new Error("Cannot parse RSS feed, feed or feed.items is undefined.");
+                }
+
+                const feedInfo: RssFeed = {
+                    title: feed.title,
+                    link: feed.link,
+                    description: feed.description,
+                    items: []
+                };
+
+                const itemsToProcess = params.count === 0 ? feed.items : feed.items.slice(0, params.count ?? 1);
+
+                for (const item of itemsToProcess) {
+                    let description = '';
+                    if (item.content) {
+                        const $ = cheerio.load(item.content);
+                        description = $.text().replace(/\s+/g, ' ').trim();
+                    } else if (item.contentSnippet) {
+                        description = item.contentSnippet;
+                    }
+
+                    let pubDate: string | undefined = undefined;
+                    if (item.pubDate) {
+                        try {
+                            pubDate = formatInTimeZone(new Date(item.pubDate), 'UTC', "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+                        } catch (e) {
+                            console.error(`Date parse error: ${e}`);
+                            pubDate = item.pubDate;
+                        }
+                    }
+
+                    const feedItem: RssItem = {
+                        title: item.title,
+                        description: description,
+                        link: item.link,
+                        guid: item.guid || item.link,
+                        pubDate: pubDate,
+                        author: item.creator,
+                        category: item.categories
+                    };
+                    feedInfo.items.push(feedItem);
+                }
+
+                return feedInfo;
+
+            } catch (error) {
+                lastError = error as Error;
+                const errorMsg = error instanceof Error ? error.message : String(error);
+                console.error(`Attempt to access ${u} failed: ${errorMsg}`);
+
+                // Add a small delay between retries to avoid overwhelming servers
+                if (urls.indexOf(u) < urls.length - 1) {
+                    await new Promise(resolve => setTimeout(resolve, 100));
+                }
+                continue;
+            }
+        }
+
+        const finalError = lastError?.message || 'Unknown error';
+        console.error(`All RSSHub instances failed. Last error: ${finalError}`);
+        throw new Error(`All RSSHub instances failed: ${finalError}`);
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+        console.error(`Unexpected error in getFeed: ${errorMessage}`);
+        throw error; // Re-throw the error to be caught by the tool handler
+    }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,5 @@
+// Export all core functionality
+
+export { getFeed, type GetFeedParams } from './feed-parser';
+export { getRsshubInstances, convertRsshubUrl } from './rsshub-instances';
+export type { RssFeed, RssItem } from './types';

--- a/src/lib/rsshub-instances.ts
+++ b/src/lib/rsshub-instances.ts
@@ -1,0 +1,52 @@
+// RSSHub instance management
+
+// Load instances from environment variable first, if available
+const priorityInstance = process.env.PRIORITY_RSSHUB_INSTANCE;
+
+let RSSHUB_INSTANCES = [
+    "https://rsshub.app",
+    "https://rsshub.rssforever.com",
+    "https://rsshub.feeded.xyz",
+    "https://hub.slarker.me",
+    "https://rsshub.liumingye.cn",
+    "https://rsshub-instance.zeabur.app",
+    "https://rss.fatpandac.com",
+    "https://rsshub.pseudoyu.com",
+    "https://rsshub.friesport.ac.cn",
+    "https://rsshub.atgw.io",
+    "https://rsshub.rss.tips",
+    "https://rsshub.mubibai.com",
+    "https://rsshub.ktachibana.party",
+    "https://rsshub.woodland.cafe",
+    "https://rsshub.aierliz.xyz",
+    "http://localhost:1200"
+];
+
+// If a priority instance is set, add it to the front of the list
+if (priorityInstance) {
+    // Remove it from the list if it already exists to avoid duplicates
+    RSSHUB_INSTANCES = RSSHUB_INSTANCES.filter(url => url !== priorityInstance);
+    RSSHUB_INSTANCES.unshift(priorityInstance);
+}
+
+export function getRsshubInstances(): string[] {
+    return [...RSSHUB_INSTANCES];
+}
+
+export function convertRsshubUrl(url: string): string[] {
+    const instances = getRsshubInstances();
+
+    if (url.startsWith('rsshub://')) {
+        const path = url.substring(9);
+        return instances.map(instance => `${instance}/${path}`);
+    }
+
+    for (const instance of instances) {
+        if (url.startsWith(instance)) {
+            const path = url.substring(instance.length).replace(/^\//, '');
+            return instances.map(inst => `${inst}/${path}`);
+        }
+    }
+
+    return [url];
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,18 @@
+// RSS Feed types
+
+export interface RssFeed {
+    title?: string;
+    link?: string;
+    description?: string;
+    items: RssItem[];
+}
+
+export interface RssItem {
+    title?: string;
+    description?: string;
+    link?: string;
+    guid?: string;
+    pubDate?: string;
+    author?: string;
+    category?: string[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,113 +1,28 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
-
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
-    /* Language and Environment */
-    "target": "ES2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["es2020","dom"],                             /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "libReplacement": true,                           /* Enable lib replacement. */
-    "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
-    "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
-    /* Modules */
-    "module": "ESNext",                                /* Specify what module code is generated. */
-    "rootDir": "src",                                    /* Specify the root folder within your source files. */
-    "moduleResolution": "node",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
-    // "rewriteRelativeImportExtensions": true,          /* Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files. */
-    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
-    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
-    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
-    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
-    "resolveJsonModule": true,                           /* Enable importing .json files. */
-    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "dist",                                    /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
-    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
-    // "erasableSyntaxOnly": true,                       /* Do not allow runtime constructs that are not part of ECMAScript. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-
-    /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "app/api/[transport]/route.ts": {
+      "maxDuration": 60
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,6 @@
 {
+  "buildCommand": "next build",
+  "framework": "nextjs",
   "functions": {
     "app/api/[transport]/route.ts": {
       "maxDuration": 60


### PR DESCRIPTION
- Add Next.js App Router structure with mcp-handler for HTTP-based MCP
- Extract core RSS parsing logic into reusable modules in src/lib/
- Create API route at /api/[transport] for MCP endpoint
- Add homepage with API documentation and client configuration examples
- Update package.json with Next.js, React, and mcp-handler dependencies
- Update tsconfig.json for Next.js compatibility
- Add vercel.json for Vercel deployment configuration
- Add .env.example for environment variable documentation
- Update README with Vercel deployment instructions and client configs
- Preserve stdio mode support via build:stdio and start:stdio scripts