### PR TITLE
fix: add shebang to make npx execution work

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";


### PR DESCRIPTION
## 问题描述 / Problem Description

修复了使用 `npx rss-mcp` 时出现 `import: not found` 错误的问题。

Fixes the "import: not found" error when running via `npx rss-mcp`.

## 根本原因 / Root Cause

源文件 `src/index.ts` 缺少 shebang (`#!/usr/bin/env node`)，导致系统将编译后的 JavaScript 文件作为 shell 脚本执行，而不是传递给 Node.js 运行时。

The source file `src/index.ts` was missing the shebang (`#!/usr/bin/env node`), causing the system to execute the compiled JavaScript file as a shell script instead of passing it to the Node.js runtime.

## 修复方案 / Solution

在 `src/index.ts` 文件开头添加 shebang。TypeScript 编译器会将源文件开头的 shebang 原样保留到编译输出中，确保 `dist/index.js` 可以作为命令行工具正确执行。

Added shebang to the beginning of `src/index.ts`. The TypeScript compiler preserves shebangs from source files in the compiled output, ensuring `dist/index.js` can be properly executed as a command-line tool.

## 测试验证 / Testing

✅ 本地构建测试通过，编译后的 `dist/index.js` 包含正确的 shebang  
✅ Local build tested successfully, compiled `dist/index.js` contains the correct shebang

## 相关 Issue / Related Issue

Fixes #3

---

感谢 @asklar 报告这个问题！  
Thanks to @asklar for reporting this issue!